### PR TITLE
feat: add redis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,18 +20,25 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'mysql:mysql-connector-java:8.0.27'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+  implementation 'org.springframework.boot:spring-boot-starter-actuator'
+  implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+  implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+  implementation 'org.springframework.boot:spring-boot-starter-security'
+  implementation 'org.springframework.boot:spring-boot-starter-web'
+  implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+  compileOnly 'org.projectlombok:lombok'
+  developmentOnly 'org.springframework.boot:spring-boot-devtools'
+  runtimeOnly 'com.h2database:h2'
+  runtimeOnly 'mysql:mysql-connector-java:8.0.27'
+  annotationProcessor 'org.projectlombok:lombok'
+  testImplementation "org.junit.jupiter:junit-jupiter:5.8.1"
+  testImplementation "org.testcontainers:testcontainers:1.17.6"
+  testImplementation "org.testcontainers:junit-jupiter:1.17.6"
+  testImplementation('org.projectlombok:lombok:1.18.20')
+  testImplementation("org.testcontainers:mysql:1.17.6")
+  testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+  testRuntimeOnly('org.projectlombok:lombok:1.18.20')
   implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
   runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
               'io.jsonwebtoken:jjwt-jackson:0.11.2'

--- a/src/main/java/com/blackcowmoo/moomark/auth/configuration/RedisConfig.java
+++ b/src/main/java/com/blackcowmoo/moomark/auth/configuration/RedisConfig.java
@@ -1,0 +1,31 @@
+package com.blackcowmoo.moomark.auth.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.redis.host}")
+  private String host;
+
+  @Value("${spring.redis.port}")
+  private int port;
+
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(host, port);
+  }
+
+  @Bean
+  public RedisTemplate<?, ?> redisTemplate() {
+    RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    return redisTemplate;
+  }
+}

--- a/src/main/java/com/blackcowmoo/moomark/auth/model/entity/PassportKey.java
+++ b/src/main/java/com/blackcowmoo/moomark/auth/model/entity/PassportKey.java
@@ -1,0 +1,27 @@
+package com.blackcowmoo.moomark.auth.model.entity;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@RedisHash(value = "Passport", timeToLive = 1800)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PassportKey implements Serializable {
+
+  @Id
+  @Column(name = "hash")
+  private String hash;
+  private byte[] key;
+
+  @Builder
+  public PassportKey(byte[] key, String hash) {
+    this.key = key;
+    this.hash = hash;
+  }
+}

--- a/src/main/java/com/blackcowmoo/moomark/auth/repository/PassportKeyRedisRepository.java
+++ b/src/main/java/com/blackcowmoo/moomark/auth/repository/PassportKeyRedisRepository.java
@@ -1,0 +1,8 @@
+package com.blackcowmoo.moomark.auth.repository;
+
+import com.blackcowmoo.moomark.auth.model.entity.PassportKey;
+import org.springframework.data.repository.CrudRepository;
+
+public interface PassportKeyRedisRepository extends CrudRepository<PassportKey, String> {
+
+}

--- a/src/main/java/com/blackcowmoo/moomark/auth/util/HashUtils.java
+++ b/src/main/java/com/blackcowmoo/moomark/auth/util/HashUtils.java
@@ -1,0 +1,30 @@
+package com.blackcowmoo.moomark.auth.util;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class HashUtils {
+
+  private HashUtils() throws InstantiationException {
+    throw new InstantiationException("HashUtils is utility class");
+  }
+
+  public static String toSha256(String msg) {
+    String result = "";
+
+    try {
+      MessageDigest md = MessageDigest.getInstance("SHA256");
+      md.update(msg.getBytes());
+      byte[] byteData = md.digest();
+      StringBuilder sb = new StringBuilder();
+      for (byte data : byteData) {
+        sb.append(Integer.toString((data & 0xff) + 0x100, 16).substring(1));
+      }
+      result = sb.toString();
+    } catch (NoSuchAlgorithmException e) {
+      e.printStackTrace();
+    }
+
+    return result;
+  }
+}

--- a/src/test/java/com/blackcowmoo/moomark/auth/configuration/AbstractContainerBaseTest.java
+++ b/src/test/java/com/blackcowmoo/moomark/auth/configuration/AbstractContainerBaseTest.java
@@ -1,0 +1,24 @@
+package com.blackcowmoo.moomark.auth.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@Configuration
+public class AbstractContainerBaseTest {
+
+  static final String REDIS_IMAGE = "redis:6-alpine";
+
+  @Value("${spring.redis.host}")
+  String redisHost;
+
+  static {
+    GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse(REDIS_IMAGE)).withExposedPorts(6379);
+    redis.start();
+    System.setProperty("spring.redis.host", redis.getHost());
+    System.setProperty("spring.redis.port", redis.getMappedPort(6379).toString());
+  }
+}

--- a/src/test/java/com/blackcowmoo/moomark/auth/repository/PassportKeyRedisRepositoryTest.java
+++ b/src/test/java/com/blackcowmoo/moomark/auth/repository/PassportKeyRedisRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.blackcowmoo.moomark.auth.repository;
+
+import com.blackcowmoo.moomark.auth.model.entity.PassportKey;
+
+import com.blackcowmoo.moomark.auth.util.AesUtil;
+import com.blackcowmoo.moomark.auth.util.HashUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Slf4j
+@Testcontainers
+@DataRedisTest
+class PassportKeyRedisRepositoryTest {
+
+  @Autowired
+  private PassportKeyRedisRepository passportKeyRedisRepository;
+  private final AesUtil aesUtil = new AesUtil();
+  private static final String DOCKER_IMG_NAME = "redis:6-alpine";
+
+  @Container
+  private static final GenericContainer<?> REDIS_CONTAINER = new GenericContainer<>(
+    DockerImageName.parse(DOCKER_IMG_NAME))
+    .withExposedPorts(6379)
+    .withReuse(true);
+
+  @DynamicPropertySource
+  public static void properties(DynamicPropertyRegistry registry) {
+    registry.add("spring.redis.host", REDIS_CONTAINER::getHost);
+    registry.add("spring.redis.port", () -> "" + REDIS_CONTAINER.getMappedPort(6379));
+
+  }
+
+  @Test
+  void saveKeyTest() {
+    PassportKey passportKey = PassportKey.builder()
+      .key(aesUtil.generateNewKey().getEncoded())
+      .hash(HashUtils.toSha256("TEST"))
+      .build();
+
+    PassportKey savedPassportKey = passportKeyRedisRepository.save(passportKey);
+    Assertions.assertThat(passportKey.getHash()).isEqualTo(savedPassportKey.getHash());
+  }
+}

--- a/src/test/java/com/blackcowmoo/moomark/auth/util/HashUtilsTest.java
+++ b/src/test/java/com/blackcowmoo/moomark/auth/util/HashUtilsTest.java
@@ -1,0 +1,19 @@
+package com.blackcowmoo.moomark.auth.util;
+
+import org.assertj.core.api.Assertions;
+
+import org.junit.jupiter.api.Test;
+
+class HashUtilsTest {
+
+  @Test
+  void sha256Test() {
+
+    String testMsg = "TEST MESSAGE";
+    String testMsg2 = "TEST MESSAGE2";
+    String result = HashUtils.toSha256(testMsg);
+    String result2 = HashUtils.toSha256(testMsg2);
+
+    Assertions.assertThat(result).isNotEqualTo(result2);
+  }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,7 +1,7 @@
 spring:
   redis:
-    host: ${REDIS_HOST:localhost}
-    port: ${REDIS_PORT:6379}
+    host: localhost
+    port: 6379
 
   security:
     oauth2:
@@ -26,7 +26,9 @@ spring:
     show-sql: true
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create-drop
+  cache:
+    type: redis
 
 passport:
   public-key: ${RSA_PUBLIC_KEY}


### PR DESCRIPTION
# Summary
- Store and manage key generation results in Redis.
- Redis and MySQL are running using Docker, but we're getting errors because of testcontainers.

## Related
- https://github.com/blackcowmoo/moomark-auth/issues/23
- https://github.com/blackcowmoo/moomark-auth/pull/30